### PR TITLE
Added device support for DEVICE_C6603_1275_1562_10_1_1_A_1_253 (Sony Xperia Z) and DEVICE_LG_E975 (LG Optimus G)

### DIFF
--- a/perf_event.c
+++ b/perf_event.c
@@ -46,8 +46,10 @@ static supported_device supported_devices[] = {
   { DEVICE_LT26W_1265_3909_6_2_B_0_200, 0xc0cafa74 },
   { DEVICE_LT26I_1257_8080_6_2_B_0_211, 0xc0caf3b4 },
   { DEVICE_C6603_1269_5309_10_1_1_A_1_307, 0xc0d1fcb4 },
+  { DEVICE_C6603_1275_1562_10_1_1_A_1_253, 0xc0d1fcb4 },
   { DEVICE_C5302_1272_1092_12_0_A_1_284, 0xc0e219b4 },
-  { DEVICE_N05E_A1000311,          0xc0f408f4 }
+  { DEVICE_N05E_A1000311,          0xc0f408f4 },
+  { DEVICE_LG_E975,				   0xc0f84234 }
 };
 
 static int n_supported_devices = sizeof(supported_devices) / sizeof(supported_devices[0]);


### PR DESCRIPTION
..._1_253) and LG Optimus G E275 (DEVICE_LG_E275)
